### PR TITLE
chore: drop PHP <7.4 support and modernize serialization API

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,85 +1,63 @@
 on: [push, pull_request]
 jobs:
-  before:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Prepare CodeClimate
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: |
-          wget https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -qO ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
   unit-tests:
-    needs: [before]
     strategy:
       matrix:
-        include:
-          - image: 'iras/php-composer:7.4'
-            php_version: 7.4
-          - image: 'iras/php-composer:8.0'
-            php_version: 8.0
-          - image: 'iras/php-composer:8.1'
-            php_version: 8.1
-          - image: 'iras/php-composer:8.2'
-            php_version: 8.2
-          - image: 'iras/php-composer:8.3'
-            php_version: 8.3
-          - image: 'iras/php-composer:8.4'
-            php_version: 8.4
-          - image: 'iras/php-composer:8.5'
-            php_version: 8.5
-    name: PHP Unit Tests on PHP ${{ matrix.php_version }}
+        php-version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+    name: PHP Unit Tests on PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
-    container: ${{ matrix.image }}
     steps:
-      - name: Container Setup
-        run: |
-          apk add --no-cache tar openssl
-          mkdir coverage
-          wget https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -qO /usr/bin/cc-test-reporter
-          chmod +x /usr/bin/cc-test-reporter
       - name: Checkout
-        run: |
-          git init && git remote add origin https://github.com/${{ github.repository }}.git
-          git fetch origin ${{ github.sha }} && git reset --hard ${{ github.sha }}
-      - uses: actions/cache@v2
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          path: /composer/cache
-          key: composer-cache-7.${{ matrix.MINOR_VERSION }}
+          php-version: ${{ matrix.php-version }}
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-cache-${{ matrix.php-version }}
+
       - name: Install dependencies
         run: composer install --no-interaction --ansi
+
       - name: Execute tests
         run: |
           php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit \
             -c phpunit.xml \
-            --coverage-clover=coverage/clover.xml \
+            --coverage-clover=coverage/clover-${{ matrix.php-version }}.xml \
             --coverage-text \
             --color=always
-      - name: Format Coverage
-        run: |
-          cc-test-reporter format-coverage -t clover -o coverage/cc-${{ matrix.php_version }}.json coverage/clover.xml
+
       - name: Store Coverage Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-results
-          path: coverage/
+          name: coverage-report-${{ matrix.php-version }}
+          path: coverage/clover-${{ matrix.php-version }}.xml
 
   after:
     needs: [unit-tests]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Restore Coverage Result
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-results
+          pattern: coverage-report-*
+          merge-multiple: true
           path: coverage/
+
       - name: Report Coverage
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: |
-          wget https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -qO ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter sum-coverage coverage/cc-*.json -p 7 -o coverage/cc-total.json
-          ./cc-test-reporter upload-coverage -i coverage/cc-total.json
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/clover-*.xml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,16 +16,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: 'iras/php7-composer:1'
-            php_version: 7.1
-          - image: 'iras/php7-composer:2'
-            php_version: 7.2
-          - image: 'iras/php7-composer:3'
-            php_version: 7.3
-          - image: 'iras/php7-composer:4'
+          - image: 'iras/php-composer:7.4'
             php_version: 7.4
-          - image: 'iras/php8-composer:0'
+          - image: 'iras/php-composer:8.0'
             php_version: 8.0
+          - image: 'iras/php-composer:8.1'
+            php_version: 8.1
+          - image: 'iras/php-composer:8.2'
+            php_version: 8.2
+          - image: 'iras/php-composer:8.3'
+            php_version: 8.3
+          - image: 'iras/php-composer:8.4'
+            php_version: 8.4
+          - image: 'iras/php-composer:8.5'
+            php_version: 8.5
     name: PHP Unit Tests on PHP ${{ matrix.php_version }}
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
@@ -77,5 +81,5 @@ jobs:
         run: |
           wget https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -qO ./cc-test-reporter
           chmod +x ./cc-test-reporter
-          ./cc-test-reporter sum-coverage coverage/cc-*.json -p 5 -o coverage/cc-total.json
+          ./cc-test-reporter sum-coverage coverage/cc-*.json -p 7 -o coverage/cc-total.json
           ./cc-test-reporter upload-coverage -i coverage/cc-total.json

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
         "testEnv"
     ],
     "require": {
-        "php":      "^7.1 || ^8.0",
+        "php":      "^7.4 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5",
-        "mockery/mockery": "1.3.*",
+        "mockery/mockery": "^1.3",
         "phpunit/phpunit": "*",
         "tflori/phpunit-printer": "*"
     },

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -20,7 +20,7 @@ class EnvFile extends \ArrayObject
     /** @var AbstractParser[] */
     protected $resolved = [];
 
-    public function __construct(array $context = null, callable $resolver = null)
+    public function __construct(?array $context = null, ?callable $resolver = null)
     {
         $this->context = $context ?? getenv();
         $this->resolver = $resolver ?? function (string $class, ...$args) {
@@ -33,7 +33,7 @@ class EnvFile extends \ArrayObject
     }
 
     /** @codeCoverageIgnore trivial */
-    public function setContext(array $context = null)
+    public function setContext(?array $context = null)
     {
         $this->context = $context ?? getenv();
     }
@@ -51,7 +51,7 @@ class EnvFile extends \ArrayObject
         return parent::offsetGet($var);
     }
 
-    public function getArrayCopy()
+    public function getArrayCopy(): array
     {
         return array_merge(parent::getArrayCopy(), array_map([$this, 'string2Var'], $this->context));
     }
@@ -134,36 +134,23 @@ class EnvFile extends \ArrayObject
 
         if (is_numeric($value)) {
             $int = (int)$value;
-            $float = (double)$value;
+            $float = (float)$value;
             return $int == $float ? $int : $float;
         }
 
         return $value;
     }
-
-    /** @codeCoverageIgnore only executed in php <7.4 */
-    public function serialize()
-    {
-        return serialize(parent::getArrayCopy());
-    }
-
+    
     /** @codeCoverageIgnore only executed in php >=7.4 */
     public function __serialize(): array
     {
         return parent::getArrayCopy();
     }
-
-    /** @codeCoverageIgnore only executed in php <7.4 */
-    public function unserialize($serialized)
-    {
-        $this->__unserialize(unserialize($serialized));
-    }
-
+    
     /**
      * @param array $data
-     * @noinspection PhpHierarchyChecksInspection
      */
-    public function __unserialize($data)
+    public function __unserialize($data):  void
     {
         foreach ($data as $key => $value) {
             $this[$key] = $value;


### PR DESCRIPTION
- Bump minimum PHP requirement from 7.1 to 7.4 in composer.json
- Replace nullable param syntax with native ?type hints in EnvFile
- Add return type to getArrayCopy(), cast double to float
- Migrate serialize/unserialize to __serialize/__unserialize (PHP 7.4+)
- Update CI matrix: drop 7.1–7.3, add 8.2–8.5; switch to new image tags
- Relax mockery/mockery constraint to ^1.3